### PR TITLE
Fix incorrect IP regression in DefPolicyPatch x64 path2

### DIFF
--- a/RDPWrapOffsetFinder/Patch.cpp
+++ b/RDPWrapOffsetFinder/Patch.cpp
@@ -171,7 +171,6 @@ void DefPolicyPatch(ZydisDecoder* decoder, size_t RVA, size_t base) {
 
             if (instruction.mnemonic == ZYDIS_MNEMONIC_JNZ)
             {
-                IP -= lastLength;
                 jmp = "_jmp";
             }
             else if (instruction.mnemonic != ZYDIS_MNEMONIC_JZ && instruction.mnemonic != ZYDIS_MNEMONIC_POP)

--- a/autoupdate/rdpwrap_templete.ini
+++ b/autoupdate/rdpwrap_templete.ini
@@ -24,7 +24,7 @@ mov_eax_1_nop_2=B8010000009090
 nop_4=90909090
 pop_eax_add_esp_12_nop_2=5883C40C9090
 CDefPolicy_Query_eax_rdi_jmp=B80001000089873806000090EB
-CDefPolicy_Query_r9d_rdi_jmp=41B90001000044898F380600000F1F4000EB
+CDefPolicy_Query_r9d_rdi_jmp=C7873806000000010000EB
 
 [SLInit]
 bServerSku=1


### PR DESCRIPTION
I don't understand why you're using `IP -= lastLength;`, it causes the offset to be located incorrectly. After I modified it, I was able to get the correct offset in versions 10.0.26100.8474, 10.0.19041.4474, and 10.0.29565.1000. Additionally, regarding `patchcode`, you can see 
[https://github.com/llccd/RDPWrapOffsetFinder/commit/36ff9c1676123670c49454b99167dbcc6d3ea6da#commitcomment-185582174](https://github.com/llccd/RDPWrapOffsetFinder/commit/36ff9c1676123670c49454b99167dbcc6d3ea6da#commitcomment-185582174), it works very well.

I also modified the solution to use static linking with zydis, so there's no need to distribute zydis.dll.

[10.0.26100.8474.zip](https://github.com/user-attachments/files/27970337/10.0.26100.8474.zip)